### PR TITLE
uefi

### DIFF
--- a/BKPR.pm
+++ b/BKPR.pm
@@ -1024,10 +1024,12 @@ sub normalize_os {
 sub validate_loader {
 	my $self = shift;
 	my $loader = shift;
-	switch($loader) {
-		case 'bhyveload'	{ return 1 }
-		case 'grub'		{ return 1 }
-		case 'uefi'		{ return 1 }
+	if ($loader eq 'bhyveload') {
+		return 1;
+	} elsif ($loader eq 'grub') {
+		return 1;
+	} elsif ($loader =~ /^uefi(-csm|)$/i) {
+		return 1;
 	}
 	return 0;
 }

--- a/BKPR/create.pm
+++ b/BKPR/create.pm
@@ -43,7 +43,7 @@ sub create {
 	$guest->{'cpu'} = $cmdopts{'c'} if ($cmdopts{'c'});
 	$guest->{'mem'} = $cmdopts{'m'} if ($cmdopts{'m'});
 	$guest->{'os'} = $cmdopts{'o'} if ($cmdopts{'o'});
-	$guest->{'loader'} = $cmdopts{'l'} if ($cmdopts{'l'});
+	$guest->{'loader'} = lc $cmdopts{'l'} if ($cmdopts{'l'});
 	$guest->{'descr'} = $cmdopts{'D'} if ($cmdopts{'D'});
 
 	$guest->{'grubmap'} = $cmdopts{'M'} if ($cmdopts{'M'});

--- a/bkpr.1
+++ b/bkpr.1
@@ -7,7 +7,7 @@
 .Nd bhyve virtual machine manager in Perl
 .\" SYNOPSIS
 .Sh SYNOPSIS
-.Nm 
+.Nm
 .Op Fl ndN Fl f Ar file
 .Ar operation
 .Op ...
@@ -26,7 +26,7 @@ No-operation (dry run) mode
 .It Fl f Ar file
 Explicit configuration file
 .El
-.It 
+.It
 An operation keyword:
 .Bl -tag -offset indent -compact -width fourfourfour
 .It Ar help
@@ -88,7 +88,7 @@ section describes those formats.
 The operating system name supplied for a guest is specified as one of the
 following strings:
 .Pp
-.Bl -tag -compact -offset indent
+.Bl -tag -compact -offset indent -width xxxxxxxxxx
 .It Ar freebsd
 .Fx
 .It Ar openbsd
@@ -108,13 +108,15 @@ The loader
 .Nm
 uses to boot the guest is specified using one of the following strings:
 .Pp
-.Bl -tag -compact -offset indent
+.Bl -tag -compact -offset indent -width xxxxxxxxxx
 .It Ar bhyveload
 bhyveload
 .It Ar grub
 grub-bhyve
 .It Ar uefi
 UEFI
+.It Ar uefi-csm
+UEFI-CSM
 .El
 .\" DISK SPEC
 .Ss DISK SPEC
@@ -205,13 +207,13 @@ passed to when creating the resource. For file-based disks this is the
 .Xr truncate 1
 utility, for zfs volumes, this is
 .Xr zfs 8
-create 
+create
 .Fl V .
 .\" NET SPEC
 .Ss NET SPEC
 Network interfaces are described using either the keyword
 .Ar auto ,
-or a double-colon delimited pair of 
+or a double-colon delimited pair of
 .Xr bridge 4
 and
 .Xr tap 4
@@ -237,7 +239,7 @@ auto       -->  bridge0, tapN
 .Fl f Ar file
 .Ar init
 .Pp
-The 
+The
 .Ar init
 operation performs the necessary setup for running
 .Nm .
@@ -565,11 +567,7 @@ grub
 .Bd -offset indent -compact
 .Oo
 .Fl l
-uefi
-.Oo
-.Fl U
-std|csm
-.Oc
+{uefi|uefi-csm}
 .Op Fl V Ar string
 .Oc
 .Ed
@@ -604,11 +602,6 @@ The majority of the flags supported by the
 .Ar start
 operation are the standard flags shown above. However, there are some
 flags only used by this operation.
-.Pp
-The
-.Fl U
-flag allows specifying which UEFI image to use. The recognized
-arguments are 'std', which is the default, or 'csm'.
 .Pp
 The
 .Fl V


### PR DESCRIPTION
- to support uefi csm for systems that require it, without needing to
  remember to override it when calling 'start', change the loader
  storage to use either 'uefi' for the standard, or 'uefi-csm' for the
  csm variant
- update the documentation